### PR TITLE
Remove warnings related to Enumerator.new in ruby 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ group :development do
   gem "bundler"
   gem "rspec"
   gem "jeweler", "~> 1.8.4"
-  gem "rcov", ">= 0"
+  gem "rcov", ">= 0" if RUBY_VERSION < "1.9"
   gem "rake"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,26 @@
 GEM
   remote: http://rubygems.org/
   specs:
-    diff-lcs (1.1.2)
+    diff-lcs (1.1.3)
     git (1.2.5)
     jeweler (1.8.4)
       bundler (~> 1.0)
       git (>= 1.2.5)
       rake
       rdoc
-    json (1.7.5)
-    json (1.7.5-java)
-    rake (0.8.7)
-    rcov (0.9.9)
-    rcov (0.9.9-java)
+    json (1.7.6)
+    json (1.7.6-java)
+    rake (10.0.3)
     rdoc (3.12)
       json (~> 1.4)
-    rspec (2.3.0)
-      rspec-core (~> 2.3.0)
-      rspec-expectations (~> 2.3.0)
-      rspec-mocks (~> 2.3.0)
-    rspec-core (2.3.1)
-    rspec-expectations (2.3.0)
-      diff-lcs (~> 1.1.2)
-    rspec-mocks (2.3.0)
+    rspec (2.12.0)
+      rspec-core (~> 2.12.0)
+      rspec-expectations (~> 2.12.0)
+      rspec-mocks (~> 2.12.0)
+    rspec-core (2.12.2)
+    rspec-expectations (2.12.1)
+      diff-lcs (~> 1.1.3)
+    rspec-mocks (2.12.1)
     stream (0.5)
 
 PLATFORMS
@@ -33,6 +31,5 @@ DEPENDENCIES
   bundler
   jeweler (~> 1.8.4)
   rake
-  rcov
   rspec
   stream (~> 0.5)

--- a/Rakefile
+++ b/Rakefile
@@ -62,20 +62,19 @@ RSpec::Core::RakeTask.new(:spec) do |spec|
   spec.pattern = FileList['spec/**/*_spec.rb']
 end
 
-#RSpec::Core::RakeTask.new(:rcov) do |spec|
-#  spec.pattern = 'spec/**/*_spec.rb'
-#  spec.rcov = true
-#end
-
-require 'rcov/rcovtask'
-Rcov::RcovTask.new do |t|
-  t.test_files = FileList['test/*.rb']
-  # t.verbose = true     # uncomment to see the executed command
+begin
+  require 'rcov/rcovtask'
+  Rcov::RcovTask.new do |t|
+    t.test_files = FileList['test/*.rb']
+    # t.verbose = true     # uncomment to see the executed command
+  end
+rescue LoadError
+  # skip
 end
 
 task :default => :test
 
-require 'rake/rdoctask'
+require 'rdoc/task'
 Rake::RDocTask.new do |rdoc|
   version = File.exist?('VERSION') ? File.read('VERSION') : ""
 

--- a/lib/rgl/transitivity.rb
+++ b/lib/rgl/transitivity.rb
@@ -1,5 +1,3 @@
-require 'enumerator'
-
 require 'rgl/adjacency'
 require 'rgl/base'
 require 'rgl/condensation'
@@ -116,7 +114,7 @@ module RGL
           # Only add the edge v -> w if there is no other edge v -> x such that
           # w is reachable from x.  Make sure to completely skip the case where
           # x == w.
-          unless Enumerator.new(cg, :each_adjacent, v).any? do |x|
+          unless cg.to_enum(:each_adjacent, v).any? do |x|
             x != w && paths_from[x].include?(w)
           end then
             tr_cg.add_edge(v, w)
@@ -157,7 +155,7 @@ module RGL
 
         # Choose a single edge between the members of two different strongly
         # connected component to add to the graph.
-        edges = Enumerator.new(self, :each_edge)
+        edges = self.to_enum(:each_edge)
         tr_cg.each_adjacent(scc) do |scc2|
           g.add_edge(
             *edges.find do |v, w|

--- a/test/TestDirectedGraph.rb
+++ b/test/TestDirectedGraph.rb
@@ -7,11 +7,11 @@ include RGL::Edge
 class TestDirectedGraph < Test::Unit::TestCase
   def setup
     @dg = DirectedAdjacencyGraph.new
-    [[1,2],[2,3],[3,2],[2,4]].each do |(src,target)| 
+    [[1,2],[2,3],[3,2],[2,4]].each do |(src,target)|
       @dg.add_edge(src, target)
     end
   end
-  
+
   def test_empty_graph
     dg = DirectedAdjacencyGraph.new
     assert dg.empty?
@@ -28,7 +28,7 @@ class TestDirectedGraph < Test::Unit::TestCase
     assert_equal(DirectedEdge,dg.edge_class)
     assert([].eql?(dg.edges))
   end
-  
+
   def test_add
     dg = DirectedAdjacencyGraph.new
     dg.add_edge(1,2)
@@ -37,18 +37,18 @@ class TestDirectedGraph < Test::Unit::TestCase
     assert(!dg.has_edge?(2,1))
     assert(dg.has_vertex?(1) && dg.has_vertex?(2))
     assert(!dg.has_vertex?(3))
-    
+
     assert_equal([1,2],dg.vertices.sort)
     assert([DirectedEdge.new(1,2)].eql?(dg.edges))
     assert_equal("(1-2)",dg.edges.join)
-    
+
     assert_equal([2],dg.adjacent_vertices(1))
     assert_equal([],dg.adjacent_vertices(2))
-    
+
     assert_equal(1,dg.out_degree(1))
     assert_equal(0,dg.out_degree(2))
   end
-  
+
   def test_edges
     assert_equal(4, @dg.edges.length)
     assert_equal([1,2,2,3], @dg.edges.map {|l| l.source}.sort)
@@ -56,11 +56,11 @@ class TestDirectedGraph < Test::Unit::TestCase
     assert_equal("(1-2)(2-3)(2-4)(3-2)", @dg.edges.map {|l| l.to_s}.sort.join)
     #    assert_equal([0,1,2,3], @dg.edges.map {|l| l.info}.sort)
   end
-  
+
   def test_vertices
     assert_equal([1,2,3,4], @dg.vertices.sort)
   end
-  
+
   def test_edges_from_to?
     assert @dg.has_edge?(1,2)
     assert @dg.has_edge?(2,3)
@@ -71,7 +71,7 @@ class TestDirectedGraph < Test::Unit::TestCase
     assert !@dg.has_edge?(4,1)
     assert !@dg.has_edge?(4,2)
   end
-  
+
   def test_remove_edges
     @dg.remove_edge 1,2
     assert !@dg.has_edge?(1,2)
@@ -82,42 +82,42 @@ class TestDirectedGraph < Test::Unit::TestCase
     assert !@dg.has_edge?(2,3)
     assert_equal('(2-4)',@dg.edges.join)
   end
-  
+
   def test_add_vertices
     dg = DirectedAdjacencyGraph.new
     dg.add_vertices 1,3,2,4
     assert_equal dg.vertices.sort, [1,2,3,4]
-    
+
     dg.remove_vertices 1,3
     assert_equal dg.vertices.sort, [2,4]
   end
-  
+
   def test_creating_from_array
     dg = DirectedAdjacencyGraph[1, 2, 3, 4]
     assert_equal([1,2,3,4], dg.vertices.sort)
     assert_equal('(1-2)(3-4)', dg.edges.join)
   end
-  
+
   def test_reverse
     reverted = @dg.reverse
     @dg.each_edge do |u,v|
       assert(reverted.has_edge?(v,u))
     end
   end
-  
-  def test_reverse
+
+  def test_reverse_with_vertex
     # Add isolated vertex
     @dg.add_vertex(42)
     reverted = @dg.reverse
-    
+
     @dg.each_edge do |u,v|
       assert(reverted.has_edge?(v,u))
     end
-    
+
     assert(reverted.has_vertex?(42),
            'Reverted graph should contain isolated Vertex 42')
   end
-  
+
   def test_to_undirected
     undirected = @dg.to_undirected
     assert_equal '(1=2)(2=3)(2=4)', undirected.edges.sort.join


### PR DESCRIPTION
I've removed two warnings related to the deprecation of `Enumerator.new` in favor of `Object#to_enum` in Ruby 2.0.

I took the opportunity to update some dependencies, skipping the rcov installation for Ruby versions other than 1.8. I've fixed a duplicated test name as well.

All tests are green for me in Ruby versions 1.8.7-p370, 1.9.3-p327, and 2.0.0-rc1. Let me know if it's all good.
